### PR TITLE
ci: publish containers to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,28 +2,14 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [ main ]
   pull_request:
-    branches: ["**"]
+    branches: [ main ]
 
 jobs:
-  ci:
-    name: Build and Test
-    runs-on: ubuntu-latest
+  call-common-ci:
+    uses: its-the-vibe/.github/.github/workflows/common-ci.yaml@main
     permissions:
       contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Download dependencies
-        run: go mod download
-
-      - name: Run CI (lint, build, test)
-        run: make ci
+      packages: write
+    secrets: inherit

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,27 @@
 # Build stage
-FROM golang:1.26.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
 
-# Install CA certificates for HTTPS
-RUN apk add --no-cache ca-certificates git
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
 # Copy go mod files
 COPY go.mod go.sum ./
 
-# Download dependencies with direct mode to bypass proxy issues
-RUN GOPROXY=direct go mod download
+# Download dependencies
+RUN go mod download
 
 # Copy source code
 COPY *.go ./
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux go build -o slack-relay
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o slack-relay
 
-# Final stage
-FROM scratch
+# Final stage (distroless)
+FROM gcr.io/distroless/static-debian13:nonroot
 
 WORKDIR /app
-
-# Copy CA certificates from builder
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
 # Copy the binary from builder
 COPY --from=builder /app/slack-relay .
@@ -32,5 +29,7 @@ COPY --from=builder /app/slack-relay .
 # Expose port (default 8080, can be overridden)
 EXPOSE 8080
 
+USER nonroot:nonroot
+
 # Run the application
-CMD ["./slack-relay"]
+ENTRYPOINT ["./slack-relay"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   slack-relay:
     build: .
+    image: ghcr.io/its-the-vibe/slackrelay:latest
+    pull_policy: always
     read_only: true
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ghcr.io/its-the-vibe/slackrelay:latest
     pull_policy: always
     read_only: true
+    user: "${UID:-65532}:${GID:-65532}"    
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:


### PR DESCRIPTION
## Summary
- Build cross-platform static binary using `--platform=$BUILDPLATFORM` with `TARGETOS`/`TARGETARCH` args
- Switch runtime from `scratch` to `gcr.io/distroless/static-debian13:nonroot` (removes CA cert copy and `apk add`)
- Add `USER nonroot:nonroot` instruction
- Update Compose to use GHCR image with `pull_policy: always`
- Delegate CI/CD to the shared organisation workflow (with `secrets: inherit`)